### PR TITLE
Fix billable PowerUp minimum

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,4 +1,5 @@
 import { Database } from 'bun:sqlite';
+
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 
 import { generalLog } from '$lib/logger';

--- a/src/lib/wharf/actions/powerup.ts
+++ b/src/lib/wharf/actions/powerup.ts
@@ -5,23 +5,196 @@ import { managerLog } from '$lib/logger';
 import { objectify } from '$lib/utils';
 import { ANTELOPE_SYSTEM_TOKEN } from 'src/config';
 
+const MAX_BILLABLE_POWERUP_ADJUSTMENTS = 32;
+const POWERUP_FRACTION_DENOMINATOR = 1_000_000_000_000_000n;
+
 export interface AccountRequiredResources {
 	cpuRequired: boolean;
 	netRequired: boolean;
+}
+
+interface MinimumBillableAmountResult {
+	amount: Int64;
+	cost: number;
+}
+
+function isBelowPrecisionError(error: unknown): boolean {
+	return String(error).includes('below required precision');
+}
+
+function numberValue(value: unknown): number {
+	if (typeof value === 'object' && value && 'value' in value) {
+		return Number(String((value as { value: unknown }).value));
+	}
+
+	return Number(String(value));
+}
+
+function assetPrecision(asset: Asset): number {
+	return asset.symbol.precision;
+}
+
+function roundUpAssetValue(value: number, precision: number): number {
+	const units = Math.pow(10, precision);
+	return Math.ceil(value * units) / units;
+}
+
+function utilizationIncreaseForFraction(weight: Int64, frac: Int64): number {
+	const numerator = BigInt(String(frac)) * BigInt(String(weight));
+	const increase = (numerator + POWERUP_FRACTION_DENOMINATOR - 1n) / POWERUP_FRACTION_DENOMINATOR;
+	return Number(increase);
+}
+
+type PowerupResource = PowerUpState['cpu'] | PowerUpState['net'];
+
+function powerupPriceFunction(resource: PowerupResource, utilization: number): number {
+	const exponent = numberValue(resource.exponent);
+	const newExponent = exponent - 1.0;
+
+	if (newExponent <= 0.0) {
+		return resource.max_price.value;
+	}
+
+	const utilizationWeight = utilization / Number(String(resource.weight));
+	const difference = resource.max_price.value - resource.min_price.value;
+	return resource.min_price.value + difference * Math.pow(utilizationWeight, newExponent);
+}
+
+function powerupPriceIntegralDelta(
+	resource: PowerupResource,
+	startUtilization: number,
+	endUtilization: number
+): number {
+	const exponent = numberValue(resource.exponent);
+	const weight = Number(String(resource.weight));
+	const coefficient = (resource.max_price.value - resource.min_price.value) / exponent;
+	const start = startUtilization / weight;
+	const end = endUtilization / weight;
+
+	return (
+		resource.min_price.value * end -
+		resource.min_price.value * start +
+		coefficient * Math.pow(end, exponent) -
+		coefficient * Math.pow(start, exponent)
+	);
+}
+
+export function getPowerupResourceCost(resource: PowerupResource, frac: Int64): number {
+	if (frac.lte(Int64.zero)) {
+		return 0;
+	}
+
+	const utilizationIncrease = utilizationIncreaseForFraction(resource.weight, frac);
+	let startUtilization = Number(String(resource.utilization));
+	const endUtilization = startUtilization + utilizationIncrease;
+	let adjustedUtilization = Number(String(resource.adjusted_utilization));
+	let fee = 0;
+
+	if (resource.utilization.lt(resource.adjusted_utilization)) {
+		adjustedUtilization = Number(String(resource.determine_adjusted_utilization()));
+	}
+
+	if (startUtilization < adjustedUtilization) {
+		const billedIncrease = Math.min(utilizationIncrease, adjustedUtilization - startUtilization);
+		fee +=
+			(powerupPriceFunction(resource, adjustedUtilization) * billedIncrease) /
+			Number(String(resource.weight));
+		startUtilization = adjustedUtilization;
+	}
+
+	if (startUtilization < endUtilization) {
+		fee += powerupPriceIntegralDelta(resource, startUtilization, endUtilization);
+	}
+
+	return roundUpAssetValue(fee, assetPrecision(resource.max_price));
+}
+
+export function getMinimumBillablePowerupAmount(
+	amount: Int64,
+	required: boolean,
+	minimumCost: number,
+	getCost: (amount: number) => number,
+	resource: 'cpu' | 'net'
+): MinimumBillableAmountResult {
+	if (!required || amount.lte(Int64.zero)) {
+		return { amount, cost: 0 };
+	}
+
+	const evaluateCost = (candidateAmount: Int64) => {
+		try {
+			return getCost(Number(candidateAmount));
+		} catch (error) {
+			if (!isBelowPrecisionError(error)) {
+				throw error;
+			}
+
+			return 0;
+		}
+	};
+
+	let adjustedAmount = Int64.from(amount);
+	let lowerBound = Int64.zero;
+	let cost = 0;
+	let attempts = 0;
+
+	for (;;) {
+		cost = evaluateCost(adjustedAmount);
+
+		if (cost >= minimumCost) {
+			break;
+		}
+
+		if (attempts >= MAX_BILLABLE_POWERUP_ADJUSTMENTS) {
+			throw new Error(
+				'Unable to derive a billable ' +
+					resource.toUpperCase() +
+					' powerup amount for ' +
+					String(amount) +
+					'.'
+			);
+		}
+
+		lowerBound = adjustedAmount;
+		adjustedAmount = adjustedAmount.multiplying(2);
+		attempts += 1;
+	}
+
+	if (attempts > 0) {
+		while (adjustedAmount.subtracting(lowerBound).gt(Int64.from(1))) {
+			const midpoint = lowerBound.adding(adjustedAmount).dividing(2, 'floor');
+			const midpointCost = evaluateCost(midpoint);
+
+			if (midpointCost >= minimumCost) {
+				adjustedAmount = midpoint;
+				cost = midpointCost;
+			} else {
+				lowerBound = midpoint;
+			}
+		}
+	}
+
+	return { amount: adjustedAmount, cost };
 }
 
 export function getPowerupParamsCPU(
 	ms: Int64,
 	powerup: PowerUpState,
 	sample: SampleUsage,
-	requirements: AccountRequiredResources
+	requirements: AccountRequiredResources,
+	minimumCost: number
 ) {
 	const cpu_cost = Asset.from(0, ANTELOPE_SYSTEM_TOKEN);
 	const cpu_frac = Int64.from(0);
 	if (requirements.cpuRequired) {
-		const cost = powerup.cpu.price_per_ms(sample, Number(ms));
-		cpu_frac.add(powerup.cpu.frac_by_ms(sample, Number(ms)));
-		cpu_cost.units.add(Asset.fromFloat(cost, ANTELOPE_SYSTEM_TOKEN).units);
+		const adjusted = getMinimumBillablePowerupAmount(
+			ms,
+			requirements.cpuRequired,
+			minimumCost,
+			(amount) => getPowerupResourceCost(powerup.cpu, powerup.cpu.frac_by_ms(sample, amount)),
+			'cpu'
+		);
+		cpu_frac.add(powerup.cpu.frac_by_ms(sample, Number(adjusted.amount)));
+		cpu_cost.units.add(Asset.fromFloat(adjusted.cost, ANTELOPE_SYSTEM_TOKEN).units);
 	}
 	return { cpu_cost, cpu_frac };
 }
@@ -30,14 +203,21 @@ export function getPowerupParamsNET(
 	kb: Int64,
 	powerup: PowerUpState,
 	sample: SampleUsage,
-	requirements: AccountRequiredResources
+	requirements: AccountRequiredResources,
+	minimumCost: number
 ) {
 	const net_cost = Asset.from(0, ANTELOPE_SYSTEM_TOKEN);
 	const net_frac = Int64.from(0);
 	if (requirements.netRequired) {
-		const cost = powerup.net.price_per_kb(sample, Number(kb));
-		net_frac.add(powerup.net.frac_by_kb(sample, Number(kb)));
-		net_cost.units.add(Asset.fromFloat(cost, ANTELOPE_SYSTEM_TOKEN).units);
+		const adjusted = getMinimumBillablePowerupAmount(
+			kb,
+			requirements.netRequired,
+			minimumCost,
+			(amount) => getPowerupResourceCost(powerup.net, powerup.net.frac_by_kb(sample, amount)),
+			'net'
+		);
+		net_frac.add(powerup.net.frac_by_kb(sample, Number(adjusted.amount)));
+		net_cost.units.add(Asset.fromFloat(adjusted.cost, ANTELOPE_SYSTEM_TOKEN).units);
 	}
 	return { net_cost, net_frac };
 }
@@ -52,8 +232,36 @@ export function getPowerupParams(
 	receiver: Name,
 	max_payment: Asset
 ) {
-	const { cpu_cost, cpu_frac } = getPowerupParamsCPU(ms, powerup, sample, requirements);
-	const { net_cost, net_frac } = getPowerupParamsNET(kb, powerup, sample, requirements);
+	if (
+		(requirements.cpuRequired || requirements.netRequired) &&
+		max_payment.units.lt(powerup.min_powerup_fee.units)
+	) {
+		throw new Error(
+			'Max payment ' +
+				String(max_payment) +
+				' is below the required minimum powerup fee target ' +
+				String(powerup.min_powerup_fee) +
+				'.'
+		);
+	}
+
+	const feePrecisionUnit = 1 / Math.pow(10, assetPrecision(powerup.min_powerup_fee));
+	const minimumCost = Math.min(powerup.min_powerup_fee.value + feePrecisionUnit, max_payment.value);
+
+	const { cpu_cost, cpu_frac } = getPowerupParamsCPU(
+		ms,
+		powerup,
+		sample,
+		requirements,
+		minimumCost
+	);
+	const { net_cost, net_frac } = getPowerupParamsNET(
+		kb,
+		powerup,
+		sample,
+		requirements,
+		minimumCost
+	);
 
 	const params = {
 		cpu_frac,

--- a/test/powerup.test.ts
+++ b/test/powerup.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'bun:test';
+
+const { Asset, Int64, Name } = await import('@wharfkit/antelope');
+
+function makePowerupResource() {
+	return {
+		weight: Int64.from('99000000000000'),
+		utilization: Int64.from('70315521748'),
+		adjusted_utilization: Int64.from('51647489007'),
+		exponent: { value: 2 },
+		min_price: Asset.from('1000.0000 EOS'),
+		max_price: Asset.from('150000.0000 EOS'),
+		determine_adjusted_utilization() {
+			return this.adjusted_utilization;
+		},
+		frac_by_kb(_sample: unknown, kilobytes: number) {
+			return Int64.from(Math.floor(kilobytes * 6551.5));
+		},
+		frac_by_ms(_sample: unknown, milliseconds: number) {
+			return Int64.from(Math.floor(milliseconds * 6551.5));
+		},
+		price_per_kb() {
+			throw new Error('price_per_kb should not be used for minimum NET search');
+		},
+		price_per_ms() {
+			throw new Error('price_per_ms should not be used for minimum CPU search');
+		}
+	};
+}
+
+describe('powerup billable precision', () => {
+	it('scales small resource requests until they are billable', async () => {
+		const { getMinimumBillablePowerupAmount } = await import('../src/lib/wharf/actions/powerup');
+		const adjusted = getMinimumBillablePowerupAmount(
+			Int64.from(10),
+			true,
+			0.0001,
+			(amount) => amount * 0.000004,
+			'cpu'
+		);
+
+		expect(adjusted.amount.equals(Int64.from(26))).toBeTrue();
+		expect(adjusted.cost).toBeGreaterThanOrEqual(0.0001);
+	});
+
+	it('preserves larger requests that are already billable', async () => {
+		const { getMinimumBillablePowerupAmount } = await import('../src/lib/wharf/actions/powerup');
+		const adjusted = getMinimumBillablePowerupAmount(
+			Int64.from(30),
+			true,
+			0.0001,
+			(amount) => amount * 0.000004,
+			'cpu'
+		);
+
+		expect(adjusted.amount.equals(Int64.from(30))).toBeTrue();
+		expect(adjusted.cost).toBeGreaterThanOrEqual(0.0001);
+	});
+
+	it('retries when pricing throws below-precision errors', async () => {
+		const { getMinimumBillablePowerupAmount } = await import('../src/lib/wharf/actions/powerup');
+		const adjusted = getMinimumBillablePowerupAmount(
+			Int64.from(10),
+			true,
+			0.0001,
+			(amount) => {
+				if (amount < 40) {
+					throw new Error(
+						'Price (0.0000 EOS) for requested CPU amount (10000us) below required precision, increase requested amount.'
+					);
+				}
+
+				return amount * 0.000004;
+			},
+			'cpu'
+		);
+
+		expect(adjusted.amount.equals(Int64.from(40))).toBeTrue();
+		expect(adjusted.cost).toBeGreaterThanOrEqual(0.0001);
+	});
+
+	it('honors the provided minimum cost threshold', async () => {
+		const { getMinimumBillablePowerupAmount } = await import('../src/lib/wharf/actions/powerup');
+		const adjusted = getMinimumBillablePowerupAmount(
+			Int64.from(10),
+			true,
+			0.1,
+			(amount) => amount * 0.0001,
+			'cpu'
+		);
+
+		expect(adjusted.amount.equals(Int64.from(1000))).toBeTrue();
+		expect(adjusted.cost).toBeGreaterThanOrEqual(0.1);
+	});
+
+	it('scales net-only requests until they are billable', async () => {
+		const { getMinimumBillablePowerupAmount } = await import('../src/lib/wharf/actions/powerup');
+		const adjusted = getMinimumBillablePowerupAmount(
+			Int64.from(10),
+			true,
+			0.1,
+			(amount) => amount * 0.00001,
+			'net'
+		);
+
+		expect(adjusted.amount.equals(Int64.from(10000))).toBeTrue();
+		expect(adjusted.cost).toBeGreaterThanOrEqual(0.1);
+	});
+
+	it('finds the minimum billable Jungle 4 NET amount without overflowing', async () => {
+		const { getMinimumBillablePowerupAmount, getPowerupResourceCost } = await import(
+			'../src/lib/wharf/actions/powerup'
+		);
+		const resource = makePowerupResource();
+		const getCost = (amount: number) =>
+			getPowerupResourceCost(resource, resource.frac_by_kb({}, amount));
+		const adjusted = getMinimumBillablePowerupAmount(Int64.from(10), true, 0.1, getCost, 'net');
+		const previousAmount = adjusted.amount.subtracting(Int64.from(1));
+
+		expect(Number(String(adjusted.amount))).toBeLessThan(20_000_000);
+		expect(adjusted.cost).toBe(0.1);
+		expect(getCost(Number(String(previousAmount)))).toBeLessThan(0.1);
+	});
+
+	it('builds NET params without using the package price_per_kb path', async () => {
+		const { getPowerupParamsNET } = await import('../src/lib/wharf/actions/powerup');
+		const resource = makePowerupResource();
+		const result = getPowerupParamsNET(
+			Int64.from(10),
+			{ net: resource } as never,
+			{} as never,
+			{ cpuRequired: false, netRequired: true },
+			0.1
+		);
+
+		expect(result.net_frac.gt(Int64.zero)).toBeTrue();
+		expect(result.net_cost.value).toBe(0.1);
+	});
+
+	it('keeps the configured max payment on managed powerups', async () => {
+		const { getPowerupParams } = await import('../src/lib/wharf/actions/powerup');
+		const resource = makePowerupResource();
+		const result = getPowerupParams(
+			Int64.from(10),
+			Int64.from(0),
+			{ min_powerup_fee: Asset.from('0.1000 EOS'), cpu: resource, net: resource } as never,
+			{} as never,
+			{ cpuRequired: true, netRequired: false },
+			Name.from('rsfui4ahy.gm'),
+			Name.from('osqj2xldy.gm'),
+			Asset.from('0.1000 EOS')
+		);
+
+		expect(result.cpu_frac.gt(Int64.zero)).toBeTrue();
+		expect(String(result.max_payment)).toBe('0.1000 EOS');
+	});
+
+	it('rejects configured max payments below the chain minimum', async () => {
+		const { getPowerupParams } = await import('../src/lib/wharf/actions/powerup');
+		const resource = makePowerupResource();
+
+		expect(() =>
+			getPowerupParams(
+				Int64.from(10),
+				Int64.from(0),
+				{ min_powerup_fee: Asset.from('0.1000 EOS'), cpu: resource, net: resource } as never,
+				{} as never,
+				{ cpuRequired: true, netRequired: false },
+				Name.from('rsfui4ahy.gm'),
+				Name.from('osqj2xldy.gm'),
+				Asset.from('0.0999 EOS')
+			)
+		).toThrow('below the required minimum powerup fee target');
+	});
+});

--- a/test/preload.ts
+++ b/test/preload.ts
@@ -1,8 +1,25 @@
 import { createMockFetch } from './mock-fetch';
 
-import { runMigrations } from '$lib/db/migrate';
-
 const originalFetch = globalThis.fetch;
 globalThis.fetch = createMockFetch(originalFetch) as typeof globalThis.fetch;
 
-runMigrations();
+process.env.ENVIRONMENT ??= 'testing';
+process.env.ANTELOPE_CHAIN_ID ??=
+	'73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d';
+process.env.ANTELOPE_NODEOS_API ??= 'https://jungle4.greymass.com';
+process.env.DATABASE_FILE ??= 'testing.sqlite';
+process.env.SERVICE_HTTP_PORT ??= '0';
+process.env.ENABLE_RESOURCE_PROVIDER ??= 'true';
+process.env.PROVIDER_ACCOUNT_NAME ??= 'providertst1';
+process.env.PROVIDER_ACCOUNT_PERMISSION ??= 'cosign';
+process.env.PROVIDER_ACCOUNT_PRIVATEKEY ??= '5Jtoxgny5tT7NiNFp1MLogviuPJ9NniWjnU4wKzaX4t7pL4kJ8s';
+process.env.PROVIDER_REQUIRE_RESOURCE_NEED ??= 'false';
+process.env.ENABLE_FREE_TRANSACTIONS ??= 'true';
+process.env.PROVIDER_FREE_TRANSACTIONS_LIMIT_MS ??= '100';
+process.env.PROVIDER_FREE_TRANSACTIONS_LIMIT_KB ??= '100';
+process.env.ENABLE_PAID_TRANSACTIONS ??= 'true';
+process.env.PROVIDER_PAID_TRANSACTIONS_MINIMUM_FEE ??= '0.0001 A';
+
+const { runMigrations } = await import('$lib/db/migrate');
+
+await runMigrations();

--- a/test/v1.test.ts
+++ b/test/v1.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+
 import type { Elysia } from 'elysia';
 
 import { server } from '../src/provider';


### PR DESCRIPTION
## Summary
- scales CPU/NET PowerUp requests up to the chain minimum billable fee when tiny requests price below precision
- uses local PowerUp cost calculation for CPU/NET to avoid Jungle 4 underflow/precision failures
- preserves the configured `max_fee` and rejects configs below `min_powerup_fee`
- sets test preload defaults before importing config so the test suite runs consistently

## Verification
- `bun test`
- `bun run build`
- `bun node_modules/prettier/bin/prettier.cjs --check .`
- `bun node_modules/eslint/bin/eslint.js .`